### PR TITLE
Setup licensed on the codespace

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
   "name": "GitHub Actions (TypeScript)",
   "image": "mcr.microsoft.com/devcontainers/typescript-node:20",
-  "postCreateCommand": "npm install",
+  "postCreateCommand": ".devcontainer/post-create",
   "customizations": {
     "codespaces": {
       "openFiles": ["README.md"]
@@ -36,6 +36,7 @@
   },
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {},
-    "ghcr.io/devcontainers-contrib/features/prettier:1": {}
+    "ghcr.io/devcontainers-contrib/features/prettier:1": {},
+    "ghcr.io/devcontainers/features/ruby:1": {}
   }
 }

--- a/.devcontainer/post-create
+++ b/.devcontainer/post-create
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -eux
+
+# Setup licensed
+sudo apt update
+sudo apt install -y \
+  cmake\
+  pkg-config
+
+gem install licensed
+
+# NPM install
+npm install
+


### PR DESCRIPTION
We use [licensed](https://github.com/licensee/licensed) to manage and validate our project dependencies' licenses. As part of our CI checks, we ensure that we're not unintentionally including any dependencies with undesired licenses.

Until now, fixing license issues required having licensed installed locally. Even though not everyone works in a Codespace, this pull request makes licensed available in the Codespace environment as a ready-to-use CLI tool.