### PR TITLE
Update model name example on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,16 +85,16 @@ steps:
 Various inputs are defined in [`action.yml`](action.yml) to let you configure
 the action:
 
-| Name                 | Description                                                                                                                                       | Default                              |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
-| `token`              | Token to use for inference. Typically the GITHUB_TOKEN secret                                                                                     | `github.token`                       |
-| `prompt`             | The prompt to send to the model                                                                                                                   | N/A                                  |
-| `prompt-file`        | Path to a file containing the prompt. If both `prompt` and `prompt-file` are provided, `prompt-file` takes precedence                             | `""`                                 |
-| `system-prompt`      | The system prompt to send to the model                                                                                                            | `"You are a helpful assistant"`      |
-| `system-prompt-file` | Path to a file containing the system prompt. If both `system-prompt` and `system-prompt-file` are provided, `system-prompt-file` takes precedence | `""`                                 |
-| `model`              | The model to use for inference. Must be available in the [GitHub Models](https://github.com/marketplace?type=models) catalog                      | `openai/gpt-4.1`                             |
-| `endpoint`           | The endpoint to use for inference. If you're running this as part of an org, you should probably use the org-specific Models endpoint             | `https://models.github.ai/inference` |
-| `max-tokens`         | The max number of tokens to generate                                                                                                              | 200                                  |
+| Name                 | Description                                                                                                                                         | Default                               |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
+| `token`              | Token to use for inference. Typically the GITHUB_TOKEN secret                                                                                  | `github.token`                        |
+| `prompt`             | The prompt to send to the model                                                                                                                | N/A                                   |
+| `prompt-file`        | Path to a file containing the prompt. If both `prompt` and `prompt-file` are provided, `prompt-file` takes precedence                          | `""`                                  |
+| `system-prompt`      | The system prompt to send to the model                                                                                                         | `"You are a helpful assistant"`       |
+| `system-prompt-file` | Path to a file containing the system prompt. If both `system-prompt` and `system-prompt-file` are provided, `system-prompt-file` takes precedence | `""`                                  |
+| `model`              | The model to use for inference. Must be available in the [GitHub Models](https://github.com/marketplace?type=models) catalog                   | `openai/gpt-4.1`                      |
+| `endpoint`           | The endpoint to use for inference. If you're running this as part of an org, you should probably use the org-specific Models endpoint          | `https://models.github.ai/inference` |
+| `max-tokens`         | The max number of tokens to generate                                                                                                           | 200                                   |
 
 ## Outputs
 


### PR DESCRIPTION
Corrected the syntax for the model identifier. The original example did not include the provider, which caused confusion and resulted in me spending 20 minutes troubleshooting with GitHub Actions.