### PR TITLE
Make actual inference in CI optional, since it depends on org settings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
 
       - name: Test Local Action
         id: test-action
+        continue-on-error: true
         uses: ./
         with:
           prompt: hello
@@ -86,6 +87,7 @@ jobs:
 
       - name: Test Local Action with Prompt File
         id: test-action-prompt-file
+        continue-on-error: true
         uses: ./
         with:
           prompt-file: prompt.txt


### PR DESCRIPTION
This is a patch to prevent CI from blocking new PRs while we wait to enable Models in the `actions` organization.