### PR TITLE
Add GitHub Actions workflow for releasing new version

### DIFF
--- a/.github/workflows/release-new-action-version.yml
+++ b/.github/workflows/release-new-action-version.yml
@@ -1,0 +1,27 @@
+name: Release new action version
+
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+    inputs:
+      TAG_NAME:
+        description: 'Tag name that the major tag will point to'
+        required: true
+
+env:
+  TAG_NAME: ${{ github.event.inputs.TAG_NAME || github.event.release.tag_name }}
+permissions:
+  contents: write
+
+jobs:
+  update_tag:
+    name: Update the major tag to include the ${{ github.event.inputs.TAG_NAME || github.event.release.tag_name }} changes
+    environment:
+      name: releaseNewActionVersion
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update the ${{ env.TAG_NAME }} tag
+        uses: actions/publish-action@v0.2.2
+        with:
+          source-tag: ${{ env.TAG_NAME }}

--- a/.github/workflows/release-new-action-version.yml
+++ b/.github/workflows/release-new-action-version.yml
@@ -16,7 +16,9 @@ permissions:
 
 jobs:
   update_tag:
-    name: Update the major tag to include the ${{ github.event.inputs.TAG_NAME || github.event.release.tag_name }} changes
+    name:
+      Update the major tag to include the ${{ github.event.inputs.TAG_NAME ||
+      github.event.release.tag_name }} changes
     environment:
       name: releaseNewActionVersion
     runs-on: ubuntu-latest

--- a/.github/workflows/release-new-action-version.yml
+++ b/.github/workflows/release-new-action-version.yml
@@ -3,24 +3,17 @@ name: Release new action version
 on:
   release:
     types: [released]
-  workflow_dispatch:
-    inputs:
-      TAG_NAME:
-        description: 'Tag name that the major tag will point to'
-        required: true
 
 env:
-  TAG_NAME: ${{ github.event.inputs.TAG_NAME || github.event.release.tag_name }}
+  TAG_NAME: ${{ github.event.release.tag_name }}
 permissions:
   contents: write
 
 jobs:
   update_tag:
     name:
-      Update the major tag to include the ${{ github.event.inputs.TAG_NAME ||
-      github.event.release.tag_name }} changes
-    environment:
-      name: releaseNewActionVersion
+      Update the major tag to include the ${{ github.event.release.tag_name }}
+      changes
     runs-on: ubuntu-latest
     steps:
       - name: Update the ${{ env.TAG_NAME }} tag


### PR DESCRIPTION
https://github.com/actions/ai-inference/issues/37

Adding this action should mean that when a new minor release is cut, it also automatically updates the major tag.