### PR TITLE
Define interfaces for multi-server support

### DIFF
--- a/src/inference.ts
+++ b/src/inference.ts
@@ -1,6 +1,6 @@
 import * as core from '@actions/core'
 import OpenAI from 'openai'
-import {GitHubMCPClient, executeToolCalls, ToolCall} from './mcp.js'
+import {MCPServerClient, executeToolCalls, ToolCall} from './mcp.js'
 
 interface ChatMessage {
   role: 'system' | 'user' | 'assistant' | 'tool'
@@ -64,7 +64,7 @@ export async function simpleInference(request: InferenceRequest): Promise<string
  */
 export async function mcpInference(
   request: InferenceRequest,
-  githubMcpClient: GitHubMCPClient,
+  githubMcpClient: MCPServerClient,
 ): Promise<string | null> {
   core.info('Running GitHub MCP inference with tools')
 


### PR DESCRIPTION
This PR introduces the foundational interfaces and type definitions needed to support multiple MCP servers while maintaining backward compatibility with the existing GitHub MCP integration.

`MCPServerConfig`: Defines configuration for any MCP server with support for:
- HTTP transport (headers, URL)
- Stdio transport (command, args, environment variables)
- Server metadata (id, name, priority, readonly flag)

`MCPServerClient`: Represents a connected MCP server instance with:
- Server configuration
- MCP client instance
- Available tools array
- Connection status tracking

`MultiServerTool`: Extends the existing `MCPTool` interface to include server identification for tool routing

`MultiMCPManager`: Interface defining the contract for managing multiple MCP servers (implementation in future PR)

**Refactored GitHub MCP Connection**
- Updated `connectToGitHubMCP()` to return the new `MCPServerClient` interface
- Added proper server configuration object with GitHub-specific settings
- Maintained identical connection behavior and error handling
- Updated `mcpInference()` function to use the new interface