### PR TITLE
ci: use read-only npm caches for validation

### DIFF
--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -23,6 +23,7 @@ jobs:
   licensed:
     name: Check Licenses
     runs-on: ubuntu-latest
+    cache-mode: read
 
     steps:
       - name: Checkout

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -17,6 +17,7 @@ jobs:
   lint:
     name: Lint Codebase
     runs-on: ubuntu-latest
+    cache-mode: read
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

- Set job-level `cache-mode: read` on the `lint` job.
- Set job-level `cache-mode: read` on the `licensed` job.
- Keep these validation-only jobs as npm cache consumers while other CI jobs retain the default read/write mode and can populate the same npm cache.

## Validation

- `npm exec --no -- prettier --check .github/workflows/linter.yml .github/workflows/licensed.yml`
- Parsed both changed workflows with the repository's `js-yaml` dependency.
- `npm test -- --reporter=dot` (4 files, 36 tests passed)